### PR TITLE
Rename conflicting variable

### DIFF
--- a/pihole-updatelists.php
+++ b/pihole-updatelists.php
@@ -603,8 +603,8 @@ if (!empty($config['ADLISTS_URL'])) {
 
         // Fetch all adlists
         $adlistsAll = [];
-        if (($sth = $dbh->prepare('SELECT * FROM `adlist`'))->execute()) {
-            $adlistsAll = $sth->fetchAll(PDO::FETCH_ASSOC);
+        if (($sthAll = $dbh->prepare('SELECT * FROM `adlist`'))->execute()) {
+            $adlistsAll = $sthAll->fetchAll(PDO::FETCH_ASSOC);
 
             $tmp = [];
             foreach ($adlistsAll as $key => $value) {


### PR DESCRIPTION
This conflicted with $sth declared previously and lead to disabling
existing lists even when REQUIRE_COMMENT is set to true.