### PR TITLE
Support single adlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build*.conf
 manifest-*.json
 Dockerfile_*
+.idea/

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ sudo nano /etc/pihole-updatelists.conf
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| ADLISTS_URL | " " | Remote list URL containing list of adlists to import <br>**URLs to single adlists are not supported here!** |
+| ADLISTS_URL | " " | Remote list URL containing list of adlists to import <br> |
 | WHITELIST_URL | " " | Remote list URL containing exact domains to whitelist |
 | REGEX_WHITELIST_URL | " " | Remote list URL containing regex rules for whitelisting |
 | BLACKLIST_URL | " " | Remote list URL containing exact domains to blacklist <br>**This is specifically for handcrafted lists only, do not use regular blocklists here!** |

--- a/pihole-updatelists.php
+++ b/pihole-updatelists.php
@@ -67,7 +67,7 @@ function printAndLog($str, $severity = 'INFO', $logOnly = false)
 /**
  * Check for required stuff
  *
- * Setting invironment variable IGNORE_OS_CHECK allows to run this script on Windows
+ * Setting environment variable IGNORE_OS_CHECK allows to run this script on Windows
  */
 function checkDependencies()
 {
@@ -1401,7 +1401,7 @@ function textToArray($text)
 
     foreach ($array as $var => &$val) {
         // Ignore empty lines and those with only a comment
-        if (empty($val) || strpos(trim($val), '#') === 0) {
+        if (empty($val) || strpos(trim($val), '#') === 0 || strpos(trim($val), '=') === 0) {
             unset($array[$var]);
             continue;
         }
@@ -1419,6 +1419,23 @@ function textToArray($text)
     unset($val);
 
     return array_values($array);
+}
+
+/**
+ *
+ * Checks if a given entry is a single adlist by checking if the first entry in the given $content is a domain
+ * instead of an URL
+ * @param string $content
+ *
+ * @return boolean
+ */
+function isSingleAdlist($content) {
+    $list = textToArray($content);
+    if (!empty($list)) {
+        $row_content = explode(' ', $list[0]);
+        return filter_var($row_content[sizeof($row_content) - 1], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+    }
+    return false;
 }
 
 /**
@@ -1738,6 +1755,10 @@ foreach ($configSections as $configSectionName => $configSectionData) {
                     printAndLog('Fetching ADLISTS from \'' . $url . '\'...');
 
                     $listContents = @fetchFileContents($url, $httpOptions);
+
+                    if (isSingleAdlist($listContents)) {
+                        $listContents = $url;
+                    }
 
                     if ($listContents !== false) {
                         printAndLog(' done' . PHP_EOL);


### PR DESCRIPTION
This pull request would allow users to specify entries in ADLISTS_URL that directly contain domains instead of links to lists of links.

Tested with the following configuration:
```
; Pi-hole's Lists Updater by Jack'lul
; https://github.com/jacklul/pihole-updatelists
; For a full list of available variables please see the readme.

; Remote list URL containing list of adlists to import
; URLs to single adlists are not supported here!
ADLISTS_URL="https://v.firebog.net/hosts/lists.php?type=tick https://raw.githubusercontent.com/Sekhan/TheGreatWall/master/TheGreatWall.txt https://raw.githubusercontent.com/jdlingyu/ad-wars/master/hosts https://v.firebog.net/hosts/Prigent-Malware.txt"

; Remote list URL containing exact domains to whitelist
WHITELIST_URL="https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt"

; Remote list URL containing regex rules for whitelisting
REGEX_WHITELIST_URL=""

; Remote list URL containing exact domains to blacklist
; This is specifically for handcrafted lists only, do not use regular blocklists here!
BLACKLIST_URL=""

; Remote list URL containing regex rules for blacklisting
REGEX_BLACKLIST_URL="https://raw.githubusercontent.com/mmotti/pihole-regex/master/regex.list"
```

Output of `/usr/local/sbin/pihole-updatelists`:

```
      Pi-hole's Lists Updater by Jack'lul
 https://github.com/jacklul/pihole-updatelists

Opened gravity database: /etc/pihole/gravity.db (33.59 MB)

Fetching ADLISTS from 'https://v.firebog.net/hosts/lists.php?type=tick'... done
Fetching ADLISTS from 'https://raw.githubusercontent.com/Sekhan/TheGreatWall/master/TheGreatWall.txt'... done
Fetching ADLISTS from 'https://raw.githubusercontent.com/jdlingyu/ad-wars/master/hosts'... done
Fetching ADLISTS from 'https://v.firebog.net/hosts/Prigent-Malware.txt'... done
Merging multiple lists... done (31 entries)
Processing... 30 exists, 1 ignored

Fetching WHITELIST from 'https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt'... done (191 entries)
Processing... 191 exists

Fetching REGEX_BLACKLIST from 'https://raw.githubusercontent.com/mmotti/pihole-regex/master/regex.list'... done (14 entries)
Processing... 14 exists

Updating Pi-hole's gravity using command '/usr/local/bin/pihole updateGravity'...  [i] Neutrino emissions detected...
  [✓] Pulling blocklist source list into range

  [✓] Preparing new gravity database
  [i] Using libz compression

  [i] Target: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 93179 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 34537 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 59 domains
  [i] List stayed unchanged

  [i] Target: https://v.firebog.net/hosts/static/w3kbl.txt
  [✓] Status: No changes detected
  [i] Analyzed 357 domains

  [i] Target: https://adaway.org/hosts.txt
  [✓] Status: No changes detected
  [i] Analyzed 8122 domains

  [i] Target: https://v.firebog.net/hosts/AdguardDNS.txt
  [✓] Status: No changes detected
  [i] Analyzed 40974 domains

  [i] Target: https://v.firebog.net/hosts/Admiral.txt
  [✓] Status: No changes detected
  [i] Analyzed 636 domains

  [i] Target: https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 42284 domains
  [i] List stayed unchanged

  [i] Target: https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
  [✓] Status: No changes detected
  [i] Analyzed 2701 domains

  [i] Target: https://v.firebog.net/hosts/Easylist.txt
  [✓] Status: No changes detected
  [i] Analyzed 15153 domains

  [i] Target: https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext
  [✓] Status: No changes detected
  [i] Analyzed 3678 domains

  [i] Target: https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 9 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 18132 domains
  [i] List stayed unchanged

  [i] Target: https://v.firebog.net/hosts/Easyprivacy.txt
  [✓] Status: No changes detected
  [i] Analyzed 11916 domains

  [i] Target: https://v.firebog.net/hosts/Prigent-Ads.txt
  [✓] Status: No changes detected
  [i] Analyzed 3670 domains

  [i] Target: https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.2o7Net/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 1286 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 378 domains
  [i] List stayed unchanged

  [i] Target: https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt
  [✓] Status: No changes detected
  [i] Analyzed 14226 domains

  [i] Target: https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 6168 domains
  [i] List stayed unchanged

  [i] Target: https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
  [✓] Status: No changes detected
  [i] Analyzed 70 domains

  [i] Target: https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
  [✓] Status: No changes detected
  [i] Analyzed 2735 domains

  [i] Target: https://v.firebog.net/hosts/Prigent-Crypto.txt
  [✓] Status: No changes detected
  [i] Analyzed 13908 domains

  [i] Target: https://bitbucket.org/ethanr/dns-blacklists/raw/8575c9f96e5b4a1308f2f12394abd86d0927a4a0/bad_lists/Mandiant_APT1_Report_Appendix_D.txt
  [✓] Status: No changes detected
  [i] Analyzed 2046 domains

  [i] Target: https://phishing.army/download/phishing_army_blocklist_extended.txt
  [✓] Status: No changes detected
  [i] Analyzed 56810 domains

  [i] Target: https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-malware.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 355 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 8154 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 2204 domains
  [i] List stayed unchanged

  [i] Target: https://urlhaus.abuse.ch/downloads/hostfile/
  [✓] Status: No changes detected
  [i] Analyzed 1241 domains

  [i] Target: https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser
  [✓] Status: Retrieval successful
  [i] Analyzed 3496 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/Sekhan/TheGreatWall/master/TheGreatWall.txt
  [✓] Status: Retrieval successful
  [i] Analyzed 132 domains
  [i] List stayed unchanged

  [i] Target: https://raw.githubusercontent.com/jdlingyu/ad-wars/master/hosts
  [✓] Status: Retrieval successful
  [i] Analyzed 1831 domains
  [i] List stayed unchanged

  [i] Target: https://v.firebog.net/hosts/Prigent-Malware.txt
  [✓] Status: No changes detected
  [i] Analyzed 168558 domains

  [✓] Storing downloaded domains in new gravity database
  [✓] Building tree
  [✓] Swapping databases
  [✓] The old database remains available.
  [i] Number of gravity domains: 559005 (428116 unique domains)
  [i] Number of exact blacklisted domains: 0
  [i] Number of regex blacklist filters: 14
  [i] Number of exact whitelisted domains: 191
  [i] Number of regex whitelist filters: 0
  [✓] Cleaning up stray matter

  [✓] DNS service is listening
     [✓] UDP (IPv4)
     [✓] TCP (IPv4)
     [✓] UDP (IPv6)
     [✓] TCP (IPv6)

  [✓] Pi-hole blocking is enabled

Finished successfully in 129.33 seconds.
```

